### PR TITLE
cmake: fail early if no module.h found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 
 # Find Tarantool and Lua dependecies
-set(TARANTOOL_FIND_REQUIRED ON)
+set(Tarantool_FIND_REQUIRED ON)
 find_package(Tarantool)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 


### PR DESCRIPTION
Commit 32e659300c9808b36eedcf85ca8f5b6e0ff9b450 ('Fix CMake warning')
causes a little regression: if there is no tarantool/module.h header, we
should fail at the cmake stage. After the fix of the warning we'll fail
only at the building stage (when `make` is called). Here I return the
old behaviour (fail on the `cmake` stage) back.

See https://github.com/tarantool/tuple-keydef/pull/20