### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/luakit-scm-1.rockspec
+++ b/luakit-scm-1.rockspec
@@ -8,7 +8,7 @@ version = 'scm-1'
 
 -- url and branch of the package's repository at GitHub
 source  = {
-    url    = 'git://github.com/tarantool/modulekit.git';
+    url    = 'git+https://github.com/tarantool/modulekit.git';
     branch = 'luakit';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587